### PR TITLE
[feat] add login

### DIFF
--- a/app/src/main/java/com/example/graduation_android/LoginMain.java
+++ b/app/src/main/java/com/example/graduation_android/LoginMain.java
@@ -131,9 +131,11 @@ public class LoginMain extends AppCompatActivity {
                     Log.v(TAG, "result= " + result.getMessage());
                     Toast.makeText(LoginMain.this, result.getMessage(), Toast.LENGTH_SHORT).show();
                     if(result.getMessage().equals("login success")) {
+                        Toast.makeText(LoginMain.this, result.getMessage(), Toast.LENGTH_SHORT).show();
                         txtId.setTextColor(Color.BLUE);
                     }
                     else {
+                        Toast.makeText(LoginMain.this, result.getMessage(), Toast.LENGTH_SHORT).show();
                         txtId.setTextColor(Color.RED);
                     }
                 }


### PR DESCRIPTION
closes #3 

나중에 토큰방식으로만 변경

임시 확인용으로 로그인 성공하면 id 텍스트가 파란색, 실패하면 빨간색으로 